### PR TITLE
Update sip-communicator.properties

### DIFF
--- a/jicofo/rootfs/defaults/sip-communicator.properties
+++ b/jicofo/rootfs/defaults/sip-communicator.properties
@@ -32,3 +32,7 @@ org.jitsi.jicofo.auth.URL=EXT_JWT:{{ .Env.XMPP_DOMAIN }}
 org.jitsi.jicofo.auth.URL=XMPP:{{ .Env.XMPP_DOMAIN }}
   {{ end }}
 {{ end }}
+
+{{ if .Env.JICOFO_EXTRA_CONFIG }}
+{{ .Env.JICOFO_EXTRA_CONFIG }}
+{{ end }}


### PR DESCRIPTION
Be able to attach extra config to sip-communicator.properties

It's handy if you need to provide additional parameters like OCTO's BridgeSelectionStrategy or undocummented options.